### PR TITLE
upgrade `:csv` to 3.0.5

### DIFF
--- a/lib/mws_client/parser.ex
+++ b/lib/mws_client/parser.ex
@@ -18,6 +18,7 @@ defmodule MWSClient.Parser do
       "text/plain;charset=" <> _charset ->
         body
         |> String.split("\r\n")
+        |> Stream.map(&"#{&1}\n")
         |> CSV.decode!(separator: ?\t, headers: true)
         |> Enum.to_list()
     end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule MWSClient.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:csv, "~> 2.4"},
+      {:csv, "~> 3.0"},
       {:elixir_xml_to_map, github: "addico/elixir-xml-to-map", branch: "master"},
       {:httpoison, "~> 1.7"},
       {:inflex, "~> 2.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "certifi": {:hex, :certifi, "2.8.0", "d4fb0a6bb20b7c9c3643e22507e42f356ac090a1dcea9ab99e27e0376d695eba", [:rebar3], [], "hexpm", "6ac7efc1c6f8600b08d625292d4bbf584e14847ce1b6b5c44d983d273e1097ea"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
-  "csv": {:hex, :csv, "2.4.1", "50e32749953b6bf9818dbfed81cf1190e38cdf24f95891303108087486c5925e", [:mix], [{:parallel_stream, "~> 1.0.4", [hex: :parallel_stream, repo: "hexpm", optional: false]}], "hexpm", "54508938ac67e27966b10ef49606e3ad5995d665d7fc2688efb3eab1307c9079"},
+  "csv": {:hex, :csv, "3.0.5", "3c1455127e92de8845806db89554ad7d45e0212974be41dd9c38a5c881861713", [:mix], [], "hexpm", "cbbe5455c93df5f3f2943e995e28b7a8808361ba34cf3e44267d77a01eaf1609"},
   "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.16", "607709303e1d4e3e02f1444df0c821529af1c03b8578dfc81bb9cf64553d02b9", [:mix], [], "hexpm", "69fcf696168f5a274dd012e3e305027010658b2d1630cef68421d6baaeaccead"},
   "elixir_xml_to_map": {:git, "https://github.com/addico/elixir-xml-to-map.git", "3ba7af9d508f70c4706c789fca10414c7099128c", [branch: "master"]},


### PR DESCRIPTION
This major version upgrade includes a breaking change in how lines are parsed when passed to `CSV.decode`; the newline at the end of each line must be included, similar to how `File.stream!` parses files.